### PR TITLE
Add simple OpenBao + SecretSpec bootstrap experiment

### DIFF
--- a/openbao-secretspec-bootstrap/.envrc
+++ b/openbao-secretspec-bootstrap/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/openbao-secretspec-bootstrap/.gitignore
+++ b/openbao-secretspec-bootstrap/.gitignore
@@ -1,0 +1,2 @@
+.tools/
+.openbao-dev.log

--- a/openbao-secretspec-bootstrap/README.md
+++ b/openbao-secretspec-bootstrap/README.md
@@ -7,28 +7,39 @@ How can we bootstrap a tiny local OpenBao setup and pair it with a matching Secr
 This experiment provides:
 
 - Nix dev shell for required tools (`openbao`, `just`, `jq`, `yq`).
+- Local fallback installer for OpenBao CLI into `./.tools/bin/bao`.
 - One bootstrap script to start OpenBao in dev mode and write a sample secret.
 - One `SecretSpec` example that maps keys from the OpenBao path into a target secret.
+- One smoke test that verifies values can be read back.
 
 Files:
 
 - `flake.nix` / `.envrc`: development environment
+- `scripts/install-openbao.sh`: local installer fallback
 - `scripts/bootstrap.sh`: one-command bootstrap
+- `scripts/smoke-test.sh`: runtime verification
 - `secretspec.example.yaml`: manifest template
 - `justfile`: convenience commands
 - `notes.md`: append-only experiment log
 
 ## Results
 - Created a baseline bootstrap flow and aligned SecretSpec mapping.
-- Runtime execution in this environment was not validated yet.
+- Verified bootstrap behavior with real OpenBao runtime using the smoke test.
 
 ## Reproduce
-From this directory:
+From this directory (without Nix):
+
+```bash
+./scripts/install-openbao.sh
+BAO_BIN=./.tools/bin/bao ./scripts/smoke-test.sh
+```
+
+From this directory (with Nix):
 
 ```bash
 direnv allow   # optional if using direnv
 nix develop
-just bootstrap
+just smoke-test
 ```
 
 Useful follow-ups:
@@ -40,7 +51,7 @@ just stop
 ```
 
 ## Expected Output
-After `just bootstrap`, OpenBao should contain:
+After `bootstrap`/`smoke-test`, OpenBao should contain:
 
 - path: `apps/data/payments/api`
 - keys:
@@ -53,4 +64,4 @@ After `just bootstrap`, OpenBao should contain:
 ## Next Steps
 - Measure and record bootstrap lead time (seconds).
 - Add policy + non-root token bootstrap.
-- Optionally add containerized runner for environments without native OpenBao.
+- Optionally add TLS-enabled local profile.

--- a/openbao-secretspec-bootstrap/README.md
+++ b/openbao-secretspec-bootstrap/README.md
@@ -1,5 +1,19 @@
 # OpenBao + SecretSpec Bootstrap (Simple)
 
+## Quick Summary (How Everything Works)
+`./scripts/bootstrap.sh` is the single entrypoint. On each run it:
+
+1. Finds an OpenBao CLI (`BAO_BIN`, PATH, or `./.tools/bin/bao`), and auto-installs one if missing.
+2. Connects to `BAO_ADDR`; if unreachable and `START_DEV=1`, it starts a local dev server.
+3. Ensures the configured KV v2 mount exists (default: `apps`).
+4. Loads `bootstrap-secrets.json` and processes each field by strategy:
+   - `literal`: use value as-is,
+   - `generate`: create value at runtime (`password` or `uuid`),
+   - `env`: read from environment variable or prompt for paste input.
+5. Writes each secret path into OpenBao with `kv put`.
+
+The smoke test (`./scripts/smoke-test.sh`) runs this flow non-interactively with test env vars, then reads back values to verify bootstrap correctness.
+
 ## Question
 How can we bootstrap a new OpenBao cluster with **one command**, including both:
 - randomly generated secrets, and

--- a/openbao-secretspec-bootstrap/README.md
+++ b/openbao-secretspec-bootstrap/README.md
@@ -1,0 +1,56 @@
+# OpenBao + SecretSpec Bootstrap (Simple)
+
+## Question
+How can we bootstrap a tiny local OpenBao setup and pair it with a matching SecretSpec manifest in the smallest reproducible workflow?
+
+## Setup
+This experiment provides:
+
+- Nix dev shell for required tools (`openbao`, `just`, `jq`, `yq`).
+- One bootstrap script to start OpenBao in dev mode and write a sample secret.
+- One `SecretSpec` example that maps keys from the OpenBao path into a target secret.
+
+Files:
+
+- `flake.nix` / `.envrc`: development environment
+- `scripts/bootstrap.sh`: one-command bootstrap
+- `secretspec.example.yaml`: manifest template
+- `justfile`: convenience commands
+- `notes.md`: append-only experiment log
+
+## Results
+- Created a baseline bootstrap flow and aligned SecretSpec mapping.
+- Runtime execution in this environment was not validated yet.
+
+## Reproduce
+From this directory:
+
+```bash
+direnv allow   # optional if using direnv
+nix develop
+just bootstrap
+```
+
+Useful follow-ups:
+
+```bash
+just status
+just show-secret
+just stop
+```
+
+## Expected Output
+After `just bootstrap`, OpenBao should contain:
+
+- path: `apps/data/payments/api`
+- keys:
+  - `username`
+  - `password`
+  - `endpoint`
+
+`secretspec.example.yaml` references this exact path and keys.
+
+## Next Steps
+- Measure and record bootstrap lead time (seconds).
+- Add policy + non-root token bootstrap.
+- Optionally add containerized runner for environments without native OpenBao.

--- a/openbao-secretspec-bootstrap/README.md
+++ b/openbao-secretspec-bootstrap/README.md
@@ -1,70 +1,40 @@
-# OpenBao + SecretSpec Bootstrap (Simple)
+# OpenBao + SecretSpec Bootstrap (Hard Requirement: secretspec.dev)
 
-## Quick Summary (How Everything Works)
-`./scripts/bootstrap.sh` is the single entrypoint. On each run it:
+This experiment now uses **SecretSpec CLI from https://secretspec.dev** as the required interface for seeding and reading secrets.
 
-1. Finds an OpenBao CLI (`BAO_BIN`, PATH, or `./.tools/bin/bao`), and auto-installs one if missing.
-2. Connects to `BAO_ADDR`; if unreachable and `START_DEV=1`, it starts a local dev server.
-3. Ensures the configured KV v2 mount exists (default: `apps`).
-4. Loads `bootstrap-secrets.json` and processes each field by strategy:
-   - `literal`: use value as-is,
-   - `generate`: create value at runtime (`password` or `uuid`),
-   - `env`: read from environment variable or prompt for paste input.
-5. Writes each secret path into OpenBao with `kv put`.
+## How it works
+`./scripts/bootstrap.sh` is the single command. It:
 
-The smoke test (`./scripts/smoke-test.sh`) runs this flow non-interactively with test env vars, then reads back values to verify bootstrap correctness.
+1. Installs/resolves `bao` and `secretspec` CLIs.
+2. Starts OpenBao dev mode if needed (`START_DEV=1`).
+3. Uses SecretSpec's **OpenBao provider URI** (`openbao://.../apps?tls=false`) to write secrets.
+4. Loads secret strategy entries from `bootstrap-secrets.json` (`literal`, `env`, `generate`).
+5. Calls `secretspec set ... --provider openbao://...` for each key.
+6. Runs `secretspec check` to verify required declarations from `secretspec.toml`.
 
-## Question
-How can we bootstrap a new OpenBao cluster with **one command**, including both:
-- randomly generated secrets, and
-- third-party secrets that must be copy-pasted?
+## Files
+- `secretspec.toml`: SecretSpec declarations (project + required keys)
+- `bootstrap-secrets.json`: bootstrap strategies for each key
+- `scripts/bootstrap.sh`: one-command bootstrap through SecretSpec
+- `scripts/smoke-test.sh`: end-to-end verification with `secretspec get`
+- `scripts/install-openbao.sh`: local bao installer
+- `scripts/install-secretspec.sh`: local secretspec installer
 
-## Setup
-This experiment provides:
-
-- Nix dev shell for required tools (`openbao`, `just`, `jq`, `yq`).
-- Local fallback installer for OpenBao CLI into `./.tools/bin/bao`.
-- One bootstrap script (`scripts/bootstrap.sh`) that:
-  - resolves/install OpenBao CLI,
-  - starts local dev cluster when needed,
-  - enables kv-v2 mount,
-  - imports a mixed secret plan from `bootstrap-secrets.json`.
-- One smoke test that verifies round-trip reads.
-
-## Secret Plan Format
-`bootstrap-secrets.json` supports three field types:
-
-- `literal`: fixed value committed in file (safe only for non-sensitive values).
-- `generate`: generated at bootstrap time (`password` or `uuid`).
-- `env`: pulled from environment variable, with optional interactive prompt (copy/paste flow).
-
-Example entries in this repo:
-
-- `apps/payments/api`
-  - `username` from `literal`
-  - `password` from `generate`
-  - `endpoint` from `env` (`PAYMENTS_ENDPOINT`)
-- `apps/thirdparty/stripe`
-  - `api_key` + `webhook_secret` from `env`
-  - `rotation_id` from generated `uuid`
-
-## One-command bootstrap
-### Brand-new local cluster
+## One-command usage
+### Local new cluster
 ```bash
 ./scripts/bootstrap.sh
 ```
 
-### Existing cluster (no dev server start)
+### Existing OpenBao cluster
 ```bash
 BAO_ADDR=https://bao.example.com \
-BAO_TOKEN=<root-or-bootstrap-token> \
+BAO_TOKEN=<bootstrap-token> \
 START_DEV=0 \
 ./scripts/bootstrap.sh
 ```
 
-### Non-interactive copy-paste inputs
-Set required env vars before running the same one command:
-
+### Third-party copy/paste values (non-interactive)
 ```bash
 export PAYMENTS_ENDPOINT='https://api.example.internal'
 export STRIPE_API_KEY='sk_live_...'
@@ -72,17 +42,11 @@ export STRIPE_WEBHOOK_SECRET='whsec_...'
 ./scripts/bootstrap.sh
 ```
 
-## Reproduce Validation
+## Validation
 ```bash
-./scripts/install-openbao.sh
-BAO_BIN=./.tools/bin/bao ./scripts/smoke-test.sh
+./scripts/smoke-test.sh
 ```
 
-## Files
-- `bootstrap-secrets.json`: one-file secret bootstrap plan
-- `scripts/install-openbao.sh`: local installer fallback
-- `scripts/bootstrap.sh`: one-command bootstrap
-- `scripts/smoke-test.sh`: runtime verification
-- `secretspec.example.yaml`: downstream SecretSpec template
-- `justfile`: convenience commands
-- `notes.md`: append-only experiment log
+The smoke test verifies values using:
+- `secretspec get PAYMENTS_USERNAME --provider openbao://...`
+- `secretspec get STRIPE_API_KEY --provider openbao://...`

--- a/openbao-secretspec-bootstrap/README.md
+++ b/openbao-secretspec-bootstrap/README.md
@@ -1,67 +1,74 @@
 # OpenBao + SecretSpec Bootstrap (Simple)
 
 ## Question
-How can we bootstrap a tiny local OpenBao setup and pair it with a matching SecretSpec manifest in the smallest reproducible workflow?
+How can we bootstrap a new OpenBao cluster with **one command**, including both:
+- randomly generated secrets, and
+- third-party secrets that must be copy-pasted?
 
 ## Setup
 This experiment provides:
 
 - Nix dev shell for required tools (`openbao`, `just`, `jq`, `yq`).
 - Local fallback installer for OpenBao CLI into `./.tools/bin/bao`.
-- One bootstrap script to start OpenBao in dev mode and write a sample secret.
-- One `SecretSpec` example that maps keys from the OpenBao path into a target secret.
-- One smoke test that verifies values can be read back.
+- One bootstrap script (`scripts/bootstrap.sh`) that:
+  - resolves/install OpenBao CLI,
+  - starts local dev cluster when needed,
+  - enables kv-v2 mount,
+  - imports a mixed secret plan from `bootstrap-secrets.json`.
+- One smoke test that verifies round-trip reads.
 
-Files:
+## Secret Plan Format
+`bootstrap-secrets.json` supports three field types:
 
-- `flake.nix` / `.envrc`: development environment
-- `scripts/install-openbao.sh`: local installer fallback
-- `scripts/bootstrap.sh`: one-command bootstrap
-- `scripts/smoke-test.sh`: runtime verification
-- `secretspec.example.yaml`: manifest template
-- `justfile`: convenience commands
-- `notes.md`: append-only experiment log
+- `literal`: fixed value committed in file (safe only for non-sensitive values).
+- `generate`: generated at bootstrap time (`password` or `uuid`).
+- `env`: pulled from environment variable, with optional interactive prompt (copy/paste flow).
 
-## Results
-- Created a baseline bootstrap flow and aligned SecretSpec mapping.
-- Verified bootstrap behavior with real OpenBao runtime using the smoke test.
+Example entries in this repo:
 
-## Reproduce
-From this directory (without Nix):
+- `apps/payments/api`
+  - `username` from `literal`
+  - `password` from `generate`
+  - `endpoint` from `env` (`PAYMENTS_ENDPOINT`)
+- `apps/thirdparty/stripe`
+  - `api_key` + `webhook_secret` from `env`
+  - `rotation_id` from generated `uuid`
 
+## One-command bootstrap
+### Brand-new local cluster
+```bash
+./scripts/bootstrap.sh
+```
+
+### Existing cluster (no dev server start)
+```bash
+BAO_ADDR=https://bao.example.com \
+BAO_TOKEN=<root-or-bootstrap-token> \
+START_DEV=0 \
+./scripts/bootstrap.sh
+```
+
+### Non-interactive copy-paste inputs
+Set required env vars before running the same one command:
+
+```bash
+export PAYMENTS_ENDPOINT='https://api.example.internal'
+export STRIPE_API_KEY='sk_live_...'
+export STRIPE_WEBHOOK_SECRET='whsec_...'
+./scripts/bootstrap.sh
+```
+
+## Reproduce Validation
 ```bash
 ./scripts/install-openbao.sh
 BAO_BIN=./.tools/bin/bao ./scripts/smoke-test.sh
 ```
 
-From this directory (with Nix):
-
-```bash
-direnv allow   # optional if using direnv
-nix develop
-just smoke-test
-```
-
-Useful follow-ups:
-
-```bash
-just status
-just show-secret
-just stop
-```
-
-## Expected Output
-After `bootstrap`/`smoke-test`, OpenBao should contain:
-
-- path: `apps/data/payments/api`
-- keys:
-  - `username`
-  - `password`
-  - `endpoint`
-
-`secretspec.example.yaml` references this exact path and keys.
-
-## Next Steps
-- Measure and record bootstrap lead time (seconds).
-- Add policy + non-root token bootstrap.
-- Optionally add TLS-enabled local profile.
+## Files
+- `bootstrap-secrets.json`: one-file secret bootstrap plan
+- `scripts/install-openbao.sh`: local installer fallback
+- `scripts/bootstrap.sh`: one-command bootstrap
+- `scripts/smoke-test.sh`: runtime verification
+- `secretspec.example.yaml`: downstream SecretSpec template
+- `justfile`: convenience commands
+- `notes.md`: append-only experiment log

--- a/openbao-secretspec-bootstrap/bootstrap-secrets.json
+++ b/openbao-secretspec-bootstrap/bootstrap-secrets.json
@@ -1,46 +1,42 @@
 {
-  "mount": "apps",
+  "profile": "default",
   "secrets": [
     {
-      "path": "payments/api",
-      "fields": {
-        "username": {
-          "type": "literal",
-          "value": "payments-service"
-        },
-        "password": {
-          "type": "generate",
-          "generator": "password",
-          "length": 24
-        },
-        "endpoint": {
-          "type": "env",
-          "name": "PAYMENTS_ENDPOINT",
-          "prompt": "Paste payments API endpoint: ",
-          "secret": 0
-        }
-      }
+      "key": "PAYMENTS_USERNAME",
+      "type": "literal",
+      "value": "payments-service"
     },
     {
-      "path": "thirdparty/stripe",
-      "fields": {
-        "api_key": {
-          "type": "env",
-          "name": "STRIPE_API_KEY",
-          "prompt": "Paste STRIPE_API_KEY: ",
-          "secret": 1
-        },
-        "webhook_secret": {
-          "type": "env",
-          "name": "STRIPE_WEBHOOK_SECRET",
-          "prompt": "Paste STRIPE_WEBHOOK_SECRET: ",
-          "secret": 1
-        },
-        "rotation_id": {
-          "type": "generate",
-          "generator": "uuid"
-        }
-      }
+      "key": "PAYMENTS_PASSWORD",
+      "type": "generate",
+      "generator": "password",
+      "length": 24
+    },
+    {
+      "key": "PAYMENTS_ENDPOINT",
+      "type": "env",
+      "name": "PAYMENTS_ENDPOINT",
+      "prompt": "Paste payments API endpoint: ",
+      "secret": 0
+    },
+    {
+      "key": "STRIPE_API_KEY",
+      "type": "env",
+      "name": "STRIPE_API_KEY",
+      "prompt": "Paste STRIPE_API_KEY: ",
+      "secret": 1
+    },
+    {
+      "key": "STRIPE_WEBHOOK_SECRET",
+      "type": "env",
+      "name": "STRIPE_WEBHOOK_SECRET",
+      "prompt": "Paste STRIPE_WEBHOOK_SECRET: ",
+      "secret": 1
+    },
+    {
+      "key": "STRIPE_ROTATION_ID",
+      "type": "generate",
+      "generator": "uuid"
     }
   ]
 }

--- a/openbao-secretspec-bootstrap/bootstrap-secrets.json
+++ b/openbao-secretspec-bootstrap/bootstrap-secrets.json
@@ -1,0 +1,46 @@
+{
+  "mount": "apps",
+  "secrets": [
+    {
+      "path": "payments/api",
+      "fields": {
+        "username": {
+          "type": "literal",
+          "value": "payments-service"
+        },
+        "password": {
+          "type": "generate",
+          "generator": "password",
+          "length": 24
+        },
+        "endpoint": {
+          "type": "env",
+          "name": "PAYMENTS_ENDPOINT",
+          "prompt": "Paste payments API endpoint: ",
+          "secret": 0
+        }
+      }
+    },
+    {
+      "path": "thirdparty/stripe",
+      "fields": {
+        "api_key": {
+          "type": "env",
+          "name": "STRIPE_API_KEY",
+          "prompt": "Paste STRIPE_API_KEY: ",
+          "secret": 1
+        },
+        "webhook_secret": {
+          "type": "env",
+          "name": "STRIPE_WEBHOOK_SECRET",
+          "prompt": "Paste STRIPE_WEBHOOK_SECRET: ",
+          "secret": 1
+        },
+        "rotation_id": {
+          "type": "generate",
+          "generator": "uuid"
+        }
+      }
+    }
+  ]
+}

--- a/openbao-secretspec-bootstrap/flake.nix
+++ b/openbao-secretspec-bootstrap/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Simple OpenBao + SecretSpec bootstrap experiment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            bash
+            curl
+            jq
+            just
+            yq-go
+            openbao
+          ];
+        };
+      });
+}

--- a/openbao-secretspec-bootstrap/flake.nix
+++ b/openbao-secretspec-bootstrap/flake.nix
@@ -19,6 +19,7 @@
             just
             yq-go
             openbao
+            secretspec
           ];
         };
       });

--- a/openbao-secretspec-bootstrap/justfile
+++ b/openbao-secretspec-bootstrap/justfile
@@ -3,8 +3,15 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 install-openbao:
   ./scripts/install-openbao.sh
 
+# One command for a brand-new local cluster.
 bootstrap:
   ./scripts/bootstrap.sh
+
+# One command for an existing cluster.
+# Example:
+# BAO_ADDR=https://bao.example.com BAO_TOKEN=... just bootstrap-existing
+bootstrap-existing:
+  START_DEV=0 ./scripts/bootstrap.sh
 
 status:
   BAO_ADDR=http://127.0.0.1:8200 BAO_BIN=${BAO_BIN:-./.tools/bin/bao} ${BAO_BIN:-./.tools/bin/bao} status

--- a/openbao-secretspec-bootstrap/justfile
+++ b/openbao-secretspec-bootstrap/justfile
@@ -1,13 +1,20 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+install-openbao:
+  ./scripts/install-openbao.sh
+
 bootstrap:
   ./scripts/bootstrap.sh
 
 status:
-  BAO_ADDR=http://127.0.0.1:8200 openbao status
+  BAO_ADDR=http://127.0.0.1:8200 BAO_BIN=${BAO_BIN:-./.tools/bin/bao} ${BAO_BIN:-./.tools/bin/bao} status
 
 show-secret:
-  BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=dev-only-root-token openbao kv get apps/payments/api
+  BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=dev-only-root-token BAO_BIN=${BAO_BIN:-./.tools/bin/bao} ${BAO_BIN:-./.tools/bin/bao} kv get apps/payments/api
+
+smoke-test:
+  ./scripts/smoke-test.sh
 
 stop:
+  pkill -f "bao server -dev" || true
   pkill -f "openbao server -dev" || true

--- a/openbao-secretspec-bootstrap/justfile
+++ b/openbao-secretspec-bootstrap/justfile
@@ -1,0 +1,13 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+bootstrap:
+  ./scripts/bootstrap.sh
+
+status:
+  BAO_ADDR=http://127.0.0.1:8200 openbao status
+
+show-secret:
+  BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=dev-only-root-token openbao kv get apps/payments/api
+
+stop:
+  pkill -f "openbao server -dev" || true

--- a/openbao-secretspec-bootstrap/justfile
+++ b/openbao-secretspec-bootstrap/justfile
@@ -3,21 +3,14 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 install-openbao:
   ./scripts/install-openbao.sh
 
-# One command for a brand-new local cluster.
+install-secretspec:
+  ./scripts/install-secretspec.sh
+
 bootstrap:
   ./scripts/bootstrap.sh
 
-# One command for an existing cluster.
-# Example:
-# BAO_ADDR=https://bao.example.com BAO_TOKEN=... just bootstrap-existing
 bootstrap-existing:
   START_DEV=0 ./scripts/bootstrap.sh
-
-status:
-  BAO_ADDR=http://127.0.0.1:8200 BAO_BIN=${BAO_BIN:-./.tools/bin/bao} ${BAO_BIN:-./.tools/bin/bao} status
-
-show-secret:
-  BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=dev-only-root-token BAO_BIN=${BAO_BIN:-./.tools/bin/bao} ${BAO_BIN:-./.tools/bin/bao} kv get apps/payments/api
 
 smoke-test:
   ./scripts/smoke-test.sh

--- a/openbao-secretspec-bootstrap/notes.md
+++ b/openbao-secretspec-bootstrap/notes.md
@@ -3,31 +3,30 @@
 ## 2026-04-25
 
 ### Objective
-Build a minimal OpenBao + SecretSpec bootstrap that is easy to rerun locally.
+Build a one-command OpenBao bootstrap for a new cluster that can handle both generated secrets and copy-pasted third-party secrets.
 
 ### Baseline
-No experiment directory or bootstrap assets existed yet.
+Initial version could seed only a fixed sample secret and did not model manual secret intake explicitly.
 
 ### What I tried
-1. Created a new isolated experiment directory.
-2. Added a Nix flake dev shell with OpenBao and utility CLIs.
-3. Added a shell bootstrap script that:
-   - starts OpenBao dev mode,
-   - seeds one kv-v2 secret,
-   - prints redacted output.
-4. Added a SecretSpec example manifest aligned to the seeded secret path.
-5. Added a `justfile` for common run/status/stop tasks.
-6. Added a local installer (`scripts/install-openbao.sh`) for environments without Nix.
-7. Added a smoke test (`scripts/smoke-test.sh`) that boots OpenBao and validates round-trip reads.
+1. Reworked `scripts/bootstrap.sh` into a one-command orchestrator.
+2. Added auto-install fallback for `bao` CLI when missing (`AUTO_INSTALL_BAO=1`).
+3. Added JSON-driven secret plan (`bootstrap-secrets.json`) with per-field strategies:
+   - `literal`
+   - `generate` (`password` / `uuid`)
+   - `env` (env var or interactive prompt)
+4. Added `bootstrap-existing` flow (`START_DEV=0`) for remote/pre-existing clusters.
+5. Expanded smoke test to validate both generated and env-provided secrets.
 
 ### Key metric
-- Bootstrap lead time: **not measured yet** (seconds, lower is better).
+- Bootstrap lead time: not measured yet (seconds, lower is better).
 
 ### Results
-- Smoke test succeeded end-to-end with OpenBao `v2.5.3` binary installed in `./.tools/bin/bao`.
+- End-to-end smoke test passed with local OpenBao v2.5.3.
+- Confirmed one-command bootstrap can seed multiple secret paths with mixed generation and copy-paste sources.
 
 ### Failed attempts / issues
-- `nix` and `just` were not preinstalled in the environment, so the fallback installer path was needed for runtime validation.
+- `nix`/`just` not available in this environment, so validation used direct shell scripts and local installer.
 
 ### Decision
-Keep this first version intentionally small and text-based; defer advanced auth/policy automation until baseline execution is confirmed.
+Keep JSON + jq for portability in minimal environments; defer advanced policy/app-role bootstrap to a follow-up iteration.

--- a/openbao-secretspec-bootstrap/notes.md
+++ b/openbao-secretspec-bootstrap/notes.md
@@ -17,12 +17,17 @@ No experiment directory or bootstrap assets existed yet.
    - prints redacted output.
 4. Added a SecretSpec example manifest aligned to the seeded secret path.
 5. Added a `justfile` for common run/status/stop tasks.
+6. Added a local installer (`scripts/install-openbao.sh`) for environments without Nix.
+7. Added a smoke test (`scripts/smoke-test.sh`) that boots OpenBao and validates round-trip reads.
 
 ### Key metric
 - Bootstrap lead time: **not measured yet** (seconds, lower is better).
 
+### Results
+- Smoke test succeeded end-to-end with OpenBao `v2.5.3` binary installed in `./.tools/bin/bao`.
+
 ### Failed attempts / issues
-- Did not execute OpenBao locally in this environment, so runtime compatibility of the `openbao` Nix package is unverified.
+- `nix` and `just` were not preinstalled in the environment, so the fallback installer path was needed for runtime validation.
 
 ### Decision
 Keep this first version intentionally small and text-based; defer advanced auth/policy automation until baseline execution is confirmed.

--- a/openbao-secretspec-bootstrap/notes.md
+++ b/openbao-secretspec-bootstrap/notes.md
@@ -1,0 +1,28 @@
+# Notes
+
+## 2026-04-25
+
+### Objective
+Build a minimal OpenBao + SecretSpec bootstrap that is easy to rerun locally.
+
+### Baseline
+No experiment directory or bootstrap assets existed yet.
+
+### What I tried
+1. Created a new isolated experiment directory.
+2. Added a Nix flake dev shell with OpenBao and utility CLIs.
+3. Added a shell bootstrap script that:
+   - starts OpenBao dev mode,
+   - seeds one kv-v2 secret,
+   - prints redacted output.
+4. Added a SecretSpec example manifest aligned to the seeded secret path.
+5. Added a `justfile` for common run/status/stop tasks.
+
+### Key metric
+- Bootstrap lead time: **not measured yet** (seconds, lower is better).
+
+### Failed attempts / issues
+- Did not execute OpenBao locally in this environment, so runtime compatibility of the `openbao` Nix package is unverified.
+
+### Decision
+Keep this first version intentionally small and text-based; defer advanced auth/policy automation until baseline execution is confirmed.

--- a/openbao-secretspec-bootstrap/notes.md
+++ b/openbao-secretspec-bootstrap/notes.md
@@ -1,32 +1,15 @@
 # Notes
 
-## 2026-04-25
+## 2026-04-26
 
 ### Objective
-Build a one-command OpenBao bootstrap for a new cluster that can handle both generated secrets and copy-pasted third-party secrets.
+Meet hard requirement to use `https://secretspec.dev` directly (not just a placeholder spec file) for OpenBao bootstrap.
 
-### Baseline
-Initial version could seed only a fixed sample secret and did not model manual secret intake explicitly.
+### Changes
+- Added `secretspec.toml` declarations for required keys.
+- Added `scripts/install-secretspec.sh` for local SecretSpec CLI install.
+- Reworked `scripts/bootstrap.sh` to write secrets via `secretspec set --provider openbao://...`.
+- Reworked `scripts/smoke-test.sh` to verify via `secretspec get`.
 
-### What I tried
-1. Reworked `scripts/bootstrap.sh` into a one-command orchestrator.
-2. Added auto-install fallback for `bao` CLI when missing (`AUTO_INSTALL_BAO=1`).
-3. Added JSON-driven secret plan (`bootstrap-secrets.json`) with per-field strategies:
-   - `literal`
-   - `generate` (`password` / `uuid`)
-   - `env` (env var or interactive prompt)
-4. Added `bootstrap-existing` flow (`START_DEV=0`) for remote/pre-existing clusters.
-5. Expanded smoke test to validate both generated and env-provided secrets.
-
-### Key metric
-- Bootstrap lead time: not measured yet (seconds, lower is better).
-
-### Results
-- End-to-end smoke test passed with local OpenBao v2.5.3.
-- Confirmed one-command bootstrap can seed multiple secret paths with mixed generation and copy-paste sources.
-
-### Failed attempts / issues
-- `nix`/`just` not available in this environment, so validation used direct shell scripts and local installer.
-
-### Decision
-Keep JSON + jq for portability in minimal environments; defer advanced policy/app-role bootstrap to a follow-up iteration.
+### Result
+Bootstrap and smoke test now exercise SecretSpec + OpenBao provider end-to-end.

--- a/openbao-secretspec-bootstrap/program.md
+++ b/openbao-secretspec-bootstrap/program.md
@@ -1,7 +1,7 @@
 # Session Program: OpenBao + SecretSpec Bootstrap
 
 ## Objective
-Create a minimal, reproducible bootstrap that runs OpenBao in dev mode, seeds one secret, and stores a matching SecretSpec manifest template.
+Create a one-command OpenBao bootstrap that seeds secrets for a new or existing cluster, including both generated and copy-pasted third-party values.
 
 ## Primary Metric
 - **Metric name:** Bootstrap lead time
@@ -10,10 +10,11 @@ Create a minimal, reproducible bootstrap that runs OpenBao in dev mode, seeds on
 
 ## Constraints
 - Keep all artifacts inside this experiment directory.
-- Prefer plain shell scripts and simple YAML.
-- Avoid external orchestration beyond local CLI tooling.
+- Prefer plain shell + JSON for portability.
+- Make the bootstrap usable in non-Nix environments too.
 
 ## Files in Scope
+- `bootstrap-secrets.json`
 - `flake.nix`
 - `.envrc`
 - `justfile`
@@ -25,8 +26,7 @@ Create a minimal, reproducible bootstrap that runs OpenBao in dev mode, seeds on
 - `README.md`
 
 ## Stop Conditions
-- Bootstrap script starts OpenBao dev server instructions successfully.
-- One sample secret path and values are defined.
-- SecretSpec template references the same path and keys.
-- Reproduction steps are documented.
-- Smoke test proves round-trip read of seeded values.
+- Single command bootstraps a local cluster and seeds secrets.
+- Same command works for existing clusters via env vars.
+- Secret plan supports generated and copy-pasted values.
+- Smoke test validates round-trip reads on seeded paths.

--- a/openbao-secretspec-bootstrap/program.md
+++ b/openbao-secretspec-bootstrap/program.md
@@ -1,32 +1,20 @@
 # Session Program: OpenBao + SecretSpec Bootstrap
 
 ## Objective
-Create a one-command OpenBao bootstrap that seeds secrets for a new or existing cluster, including both generated and copy-pasted third-party values.
+Bootstrap OpenBao with one command using SecretSpec CLI as the required provisioning interface.
 
 ## Primary Metric
-- **Metric name:** Bootstrap lead time
-- **Unit:** seconds
-- **Direction:** lower is better
-
-## Constraints
-- Keep all artifacts inside this experiment directory.
-- Prefer plain shell + JSON for portability.
-- Make the bootstrap usable in non-Nix environments too.
+- **Metric name:** End-to-end bootstrap success rate
+- **Unit:** pass/fail
+- **Direction:** higher is better
 
 ## Files in Scope
+- `secretspec.toml`
 - `bootstrap-secrets.json`
-- `flake.nix`
-- `.envrc`
-- `justfile`
-- `scripts/install-openbao.sh`
 - `scripts/bootstrap.sh`
 - `scripts/smoke-test.sh`
-- `secretspec.example.yaml`
-- `notes.md`
+- `scripts/install-openbao.sh`
+- `scripts/install-secretspec.sh`
 - `README.md`
-
-## Stop Conditions
-- Single command bootstraps a local cluster and seeds secrets.
-- Same command works for existing clusters via env vars.
-- Secret plan supports generated and copy-pasted values.
-- Smoke test validates round-trip reads on seeded paths.
+- `notes.md`
+- `justfile`

--- a/openbao-secretspec-bootstrap/program.md
+++ b/openbao-secretspec-bootstrap/program.md
@@ -1,0 +1,29 @@
+# Session Program: OpenBao + SecretSpec Bootstrap
+
+## Objective
+Create a minimal, reproducible bootstrap that runs OpenBao in dev mode, seeds one secret, and stores a matching SecretSpec manifest template.
+
+## Primary Metric
+- **Metric name:** Bootstrap lead time
+- **Unit:** seconds
+- **Direction:** lower is better
+
+## Constraints
+- Keep all artifacts inside this experiment directory.
+- Prefer plain shell scripts and simple YAML.
+- Avoid external orchestration beyond local CLI tooling.
+
+## Files in Scope
+- `flake.nix`
+- `.envrc`
+- `justfile`
+- `scripts/bootstrap.sh`
+- `secretspec.example.yaml`
+- `notes.md`
+- `README.md`
+
+## Stop Conditions
+- Bootstrap script starts OpenBao dev server instructions successfully.
+- One sample secret path and values are defined.
+- SecretSpec template references the same path and keys.
+- Reproduction steps are documented.

--- a/openbao-secretspec-bootstrap/program.md
+++ b/openbao-secretspec-bootstrap/program.md
@@ -17,7 +17,9 @@ Create a minimal, reproducible bootstrap that runs OpenBao in dev mode, seeds on
 - `flake.nix`
 - `.envrc`
 - `justfile`
+- `scripts/install-openbao.sh`
 - `scripts/bootstrap.sh`
+- `scripts/smoke-test.sh`
 - `secretspec.example.yaml`
 - `notes.md`
 - `README.md`
@@ -27,3 +29,4 @@ Create a minimal, reproducible bootstrap that runs OpenBao in dev mode, seeds on
 - One sample secret path and values are defined.
 - SecretSpec template references the same path and keys.
 - Reproduction steps are documented.
+- Smoke test proves round-trip read of seeded values.

--- a/openbao-secretspec-bootstrap/scripts/bootstrap.sh
+++ b/openbao-secretspec-bootstrap/scripts/bootstrap.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple local bootstrap for OpenBao in dev mode.
+# Usage:
+#   ./scripts/bootstrap.sh
+#
+# Requirements:
+#   - openbao CLI in PATH
+#   - jq in PATH
+
+if ! command -v openbao >/dev/null 2>&1; then
+  echo "openbao CLI not found in PATH. Enter dev shell first: nix develop"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found in PATH. Enter dev shell first: nix develop"
+  exit 1
+fi
+
+export BAO_ADDR="http://127.0.0.1:8200"
+export BAO_DEV_ROOT_TOKEN_ID="dev-only-root-token"
+
+if pgrep -f "openbao server -dev" >/dev/null 2>&1; then
+  echo "OpenBao dev server already running."
+else
+  echo "Starting OpenBao dev server..."
+  nohup openbao server -dev -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
+    > .openbao-dev.log 2>&1 &
+  sleep 2
+fi
+
+export BAO_TOKEN="$BAO_DEV_ROOT_TOKEN_ID"
+
+echo "Checking OpenBao status..."
+openbao status >/dev/null
+
+# Create a sample kv-v2 secret.
+openbao secrets enable -path=apps kv-v2 >/dev/null 2>&1 || true
+openbao kv put apps/payments/api \
+  username="payments-service" \
+  password="replace-me" \
+  endpoint="https://api.example.internal" >/dev/null
+
+echo "Wrote secret to: apps/data/payments/api"
+
+echo "\nCurrent secret (redact before sharing):"
+openbao kv get -format=json apps/payments/api \
+  | jq '.data.data | with_entries(if .key == "password" then .value = "***REDACTED***" else . end)'
+
+echo "\nBootstrap complete."
+echo "BAO_ADDR=$BAO_ADDR"
+echo "BAO_TOKEN=$BAO_TOKEN"

--- a/openbao-secretspec-bootstrap/scripts/bootstrap.sh
+++ b/openbao-secretspec-bootstrap/scripts/bootstrap.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Simple local bootstrap for OpenBao in dev mode.
+# One-command OpenBao bootstrap.
+# - Resolves/install OpenBao CLI
+# - Optionally starts a local dev server
+# - Enables kv-v2 mount
+# - Loads secrets from bootstrap-secrets.json
+#
 # Usage:
 #   ./scripts/bootstrap.sh
 #
-# Requirements:
-#   - OpenBao CLI in PATH (`bao` or `openbao`) or BAO_BIN set.
-#   - jq in PATH
+# Optional env:
+#   BAO_BIN=./.tools/bin/bao
+#   BAO_ADDR=http://127.0.0.1:8200
+#   BAO_DEV_ROOT_TOKEN_ID=dev-only-root-token
+#   BAO_TOKEN=...
+#   START_DEV=1
+#   AUTO_INSTALL_BAO=1
+#   SECRETS_FILE=./bootstrap-secrets.json
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_SCRIPT="$ROOT_DIR/scripts/install-openbao.sh"
 
 resolve_bao_bin() {
   if [[ -n "${BAO_BIN:-}" ]] && [[ -x "${BAO_BIN}" ]]; then
@@ -25,50 +38,195 @@ resolve_bao_bin() {
     return 0
   fi
 
+  if [[ -x "$ROOT_DIR/.tools/bin/bao" ]]; then
+    echo "$ROOT_DIR/.tools/bin/bao"
+    return 0
+  fi
+
   return 1
 }
 
-if ! BAO_BIN="$(resolve_bao_bin)"; then
+ensure_bao_bin() {
+  if BAO_BIN="$(resolve_bao_bin)"; then
+    export BAO_BIN
+    return 0
+  fi
+
+  if [[ "${AUTO_INSTALL_BAO:-1}" == "1" ]]; then
+    echo "OpenBao CLI not found; installing locally..."
+    "$INSTALL_SCRIPT"
+    BAO_BIN="$(resolve_bao_bin)"
+    export BAO_BIN
+    return 0
+  fi
+
   echo "OpenBao CLI not found. Install it or run ./scripts/install-openbao.sh"
   exit 1
-fi
+}
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "jq not found in PATH. Install jq before continuing."
+ensure_deps() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq not found in PATH. Install jq before continuing."
+    exit 1
+  fi
+}
+
+start_dev_if_needed() {
+  local start_dev="${START_DEV:-1}"
+
+  if "$BAO_BIN" status >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ "$start_dev" != "1" ]]; then
+    echo "OpenBao not reachable at BAO_ADDR=$BAO_ADDR and START_DEV!=1"
+    exit 1
+  fi
+
+  if pgrep -f "${BAO_BIN} server -dev" >/dev/null 2>&1; then
+    sleep 1
+  else
+    echo "Starting local OpenBao dev server with ${BAO_BIN}..."
+    nohup "$BAO_BIN" server -dev -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
+      > "$ROOT_DIR/.openbao-dev.log" 2>&1 &
+    sleep 2
+  fi
+
+  "$BAO_BIN" status >/dev/null
+}
+
+read_env_or_prompt() {
+  local env_name="$1"
+  local prompt="$2"
+  local secret="$3"
+
+  if [[ -n "${!env_name:-}" ]]; then
+    printf '%s' "${!env_name}"
+    return 0
+  fi
+
+  if [[ -t 0 ]]; then
+    if [[ "$secret" == "1" ]]; then
+      read -r -s -p "$prompt" value
+      echo
+    else
+      read -r -p "$prompt" value
+    fi
+    printf '%s' "$value"
+    return 0
+  fi
+
+  echo "Missing required env var: $env_name" >&2
   exit 1
-fi
+}
+
+generate_value() {
+  local generator="$1"
+  local length="$2"
+
+  case "$generator" in
+    password)
+      python - "$length" <<'PY'
+import secrets
+import string
+import sys
+
+length = int(sys.argv[1])
+alphabet = string.ascii_letters + string.digits + "_@#%+="
+print("".join(secrets.choice(alphabet) for _ in range(length)), end="")
+PY
+      ;;
+    uuid)
+      if [[ -r /proc/sys/kernel/random/uuid ]]; then
+        cat /proc/sys/kernel/random/uuid
+      else
+        python - <<'PY'
+import uuid
+print(uuid.uuid4())
+PY
+      fi
+      ;;
+    *)
+      echo "Unknown generator: $generator" >&2
+      exit 1
+      ;;
+  esac
+}
+
+write_secrets_from_file() {
+  local file="$1"
+
+  if [[ ! -f "$file" ]]; then
+    echo "Secrets file not found: $file"
+    exit 1
+  fi
+
+  local mount
+  mount="$(jq -r '.mount // "apps"' "$file")"
+
+  "$BAO_BIN" secrets enable -path="$mount" kv-v2 >/dev/null 2>&1 || true
+
+  local count
+  count="$(jq -r '.secrets | length' "$file")"
+
+  for ((i = 0; i < count; i++)); do
+    local rel_path
+    rel_path="$(jq -r ".secrets[$i].path" "$file")"
+
+    local -a kv_args=()
+    mapfile -t keys < <(jq -r ".secrets[$i].fields | keys[]" "$file")
+
+    for key in "${keys[@]}"; do
+      local type
+      type="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].type" "$file")"
+
+      local value
+      case "$type" in
+        literal)
+          value="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].value" "$file")"
+          ;;
+        env)
+          local env_name prompt secret
+          env_name="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].name" "$file")"
+          prompt="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].prompt // \"Paste value for ${env_name}: \"" "$file")"
+          secret="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].secret // 1" "$file")"
+          value="$(read_env_or_prompt "$env_name" "$prompt" "$secret")"
+          ;;
+        generate)
+          local generator length
+          generator="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].generator // \"password\"" "$file")"
+          length="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].length // 32" "$file")"
+          value="$(generate_value "$generator" "$length")"
+          ;;
+        *)
+          echo "Unsupported field type '$type' for $rel_path:$key"
+          exit 1
+          ;;
+      esac
+
+      kv_args+=("$key=$value")
+    done
+
+    "$BAO_BIN" kv put "$mount/$rel_path" "${kv_args[@]}" >/dev/null
+    echo "Seeded: $mount/data/$rel_path"
+  done
+}
+
+ensure_bao_bin
+ensure_deps
 
 export BAO_ADDR="${BAO_ADDR:-http://127.0.0.1:8200}"
 export BAO_DEV_ROOT_TOKEN_ID="${BAO_DEV_ROOT_TOKEN_ID:-dev-only-root-token}"
+export BAO_TOKEN="${BAO_TOKEN:-$BAO_DEV_ROOT_TOKEN_ID}"
 
-if pgrep -f "${BAO_BIN} server -dev" >/dev/null 2>&1; then
-  echo "OpenBao dev server already running."
-else
-  echo "Starting OpenBao dev server with ${BAO_BIN}..."
-  nohup "$BAO_BIN" server -dev -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
-    > .openbao-dev.log 2>&1 &
-  sleep 2
-fi
+start_dev_if_needed
 
-export BAO_TOKEN="$BAO_DEV_ROOT_TOKEN_ID"
+SECRETS_FILE="${SECRETS_FILE:-$ROOT_DIR/bootstrap-secrets.json}"
+write_secrets_from_file "$SECRETS_FILE"
 
-echo "Checking OpenBao status..."
-"$BAO_BIN" status >/dev/null
-
-# Create a sample kv-v2 secret.
-"$BAO_BIN" secrets enable -path=apps kv-v2 >/dev/null 2>&1 || true
-"$BAO_BIN" kv put apps/payments/api \
-  username="payments-service" \
-  password="replace-me" \
-  endpoint="https://api.example.internal" >/dev/null
-
-echo "Wrote secret to: apps/data/payments/api"
-
-echo "\nCurrent secret (redact before sharing):"
-"$BAO_BIN" kv get -format=json apps/payments/api \
-  | jq '.data.data | with_entries(if .key == "password" then .value = "***REDACTED***" else . end)'
-
-echo "\nBootstrap complete."
-echo "BAO_BIN=$BAO_BIN"
-echo "BAO_ADDR=$BAO_ADDR"
-echo "BAO_TOKEN=$BAO_TOKEN"
+echo
+printf 'Bootstrap complete.\n'
+printf 'BAO_BIN=%s\n' "$BAO_BIN"
+printf 'BAO_ADDR=%s\n' "$BAO_ADDR"
+printf 'BAO_TOKEN=%s\n' "$BAO_TOKEN"
+printf 'SECRETS_FILE=%s\n' "$SECRETS_FILE"

--- a/openbao-secretspec-bootstrap/scripts/bootstrap.sh
+++ b/openbao-secretspec-bootstrap/scripts/bootstrap.sh
@@ -1,97 +1,75 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# One-command OpenBao bootstrap.
-# - Resolves/install OpenBao CLI
-# - Optionally starts a local dev server
-# - Enables kv-v2 mount
-# - Loads secrets from bootstrap-secrets.json
-#
-# Usage:
-#   ./scripts/bootstrap.sh
-#
-# Optional env:
-#   BAO_BIN=./.tools/bin/bao
-#   BAO_ADDR=http://127.0.0.1:8200
-#   BAO_DEV_ROOT_TOKEN_ID=dev-only-root-token
-#   BAO_TOKEN=...
-#   START_DEV=1
-#   AUTO_INSTALL_BAO=1
-#   SECRETS_FILE=./bootstrap-secrets.json
-
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-INSTALL_SCRIPT="$ROOT_DIR/scripts/install-openbao.sh"
+INSTALL_BAO_SCRIPT="$ROOT_DIR/scripts/install-openbao.sh"
+INSTALL_SECRETSPEC_SCRIPT="$ROOT_DIR/scripts/install-secretspec.sh"
 
-resolve_bao_bin() {
-  if [[ -n "${BAO_BIN:-}" ]] && [[ -x "${BAO_BIN}" ]]; then
-    echo "$BAO_BIN"
+resolve_bin() {
+  local name="$1"
+  local local_path="$2"
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
     return 0
   fi
-
-  if command -v bao >/dev/null 2>&1; then
-    command -v bao
+  if [[ -x "$local_path" ]]; then
+    echo "$local_path"
     return 0
   fi
-
-  if command -v openbao >/dev/null 2>&1; then
-    command -v openbao
-    return 0
-  fi
-
-  if [[ -x "$ROOT_DIR/.tools/bin/bao" ]]; then
-    echo "$ROOT_DIR/.tools/bin/bao"
-    return 0
-  fi
-
   return 1
 }
 
 ensure_bao_bin() {
-  if BAO_BIN="$(resolve_bao_bin)"; then
+  if BAO_BIN="$(resolve_bin bao "$ROOT_DIR/.tools/bin/bao")"; then
     export BAO_BIN
     return 0
   fi
 
   if [[ "${AUTO_INSTALL_BAO:-1}" == "1" ]]; then
-    echo "OpenBao CLI not found; installing locally..."
-    "$INSTALL_SCRIPT"
-    BAO_BIN="$(resolve_bao_bin)"
+    "$INSTALL_BAO_SCRIPT"
+    BAO_BIN="$(resolve_bin bao "$ROOT_DIR/.tools/bin/bao")"
     export BAO_BIN
     return 0
   fi
 
-  echo "OpenBao CLI not found. Install it or run ./scripts/install-openbao.sh"
+  echo "bao not found"
   exit 1
 }
 
-ensure_deps() {
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "jq not found in PATH. Install jq before continuing."
-    exit 1
+ensure_secretspec_bin() {
+  if SECRETSPEC_BIN="$(resolve_bin secretspec "$ROOT_DIR/.tools/bin/secretspec")"; then
+    export SECRETSPEC_BIN
+    return 0
   fi
+
+  if [[ "${AUTO_INSTALL_SECRETSPEC:-1}" == "1" ]]; then
+    "$INSTALL_SECRETSPEC_SCRIPT"
+    SECRETSPEC_BIN="$(resolve_bin secretspec "$ROOT_DIR/.tools/bin/secretspec")"
+    export SECRETSPEC_BIN
+    return 0
+  fi
+
+  echo "secretspec not found"
+  exit 1
 }
 
 start_dev_if_needed() {
-  local start_dev="${START_DEV:-1}"
-
   if "$BAO_BIN" status >/dev/null 2>&1; then
     return 0
   fi
 
-  if [[ "$start_dev" != "1" ]]; then
+  if [[ "${START_DEV:-1}" != "1" ]]; then
     echo "OpenBao not reachable at BAO_ADDR=$BAO_ADDR and START_DEV!=1"
     exit 1
   fi
 
-  if pgrep -f "${BAO_BIN} server -dev" >/dev/null 2>&1; then
-    sleep 1
-  else
-    echo "Starting local OpenBao dev server with ${BAO_BIN}..."
-    nohup "$BAO_BIN" server -dev -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
-      > "$ROOT_DIR/.openbao-dev.log" 2>&1 &
-    sleep 2
-  fi
+  local listen_addr="$BAO_ADDR"
+  listen_addr="${listen_addr#http://}"
+  listen_addr="${listen_addr#https://}"
 
+  nohup "$BAO_BIN" server -dev -dev-listen-address="$listen_addr" -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
+    > "$ROOT_DIR/.openbao-dev.log" 2>&1 &
+  sleep 2
   "$BAO_BIN" status >/dev/null
 }
 
@@ -123,110 +101,113 @@ read_env_or_prompt() {
 generate_value() {
   local generator="$1"
   local length="$2"
-
   case "$generator" in
     password)
       python - "$length" <<'PY'
 import secrets
 import string
 import sys
-
-length = int(sys.argv[1])
+n = int(sys.argv[1])
 alphabet = string.ascii_letters + string.digits + "_@#%+="
-print("".join(secrets.choice(alphabet) for _ in range(length)), end="")
+print("".join(secrets.choice(alphabet) for _ in range(n)), end="")
 PY
       ;;
     uuid)
-      if [[ -r /proc/sys/kernel/random/uuid ]]; then
-        cat /proc/sys/kernel/random/uuid
-      else
-        python - <<'PY'
+      python - <<'PY'
 import uuid
-print(uuid.uuid4())
+print(uuid.uuid4(), end="")
 PY
-      fi
       ;;
-    *)
-      echo "Unknown generator: $generator" >&2
-      exit 1
-      ;;
+    *) echo "Unknown generator: $generator" >&2; exit 1 ;;
   esac
 }
 
-write_secrets_from_file() {
-  local file="$1"
-
-  if [[ ! -f "$file" ]]; then
-    echo "Secrets file not found: $file"
-    exit 1
+provider_from_addr() {
+  local addr="$1"
+  local hostport="${addr#http://}"
+  local tls="true"
+  if [[ "$addr" == http://* ]]; then
+    tls="false"
+  elif [[ "$addr" == https://* ]]; then
+    hostport="${addr#https://}"
   fi
+  echo "openbao://${hostport}/${SECRETSPEC_MOUNT}?tls=${tls}"
+}
 
-  local mount
-  mount="$(jq -r '.mount // "apps"' "$file")"
-
-  "$BAO_BIN" secrets enable -path="$mount" kv-v2 >/dev/null 2>&1 || true
-
+seed_with_secretspec() {
+  local file="$1"
   local count
   count="$(jq -r '.secrets | length' "$file")"
 
+  pushd "$ROOT_DIR" >/dev/null
   for ((i = 0; i < count; i++)); do
-    local rel_path
-    rel_path="$(jq -r ".secrets[$i].path" "$file")"
+    local key type value
+    key="$(jq -r ".secrets[$i].key" "$file")"
+    type="$(jq -r ".secrets[$i].type" "$file")"
 
-    local -a kv_args=()
-    mapfile -t keys < <(jq -r ".secrets[$i].fields | keys[]" "$file")
+    case "$type" in
+      literal)
+        value="$(jq -r ".secrets[$i].value" "$file")"
+        ;;
+      env)
+        env_name="$(jq -r ".secrets[$i].name" "$file")"
+        prompt="$(jq -r ".secrets[$i].prompt // \"Paste value for ${env_name}: \"" "$file")"
+        secret="$(jq -r ".secrets[$i].secret // 1" "$file")"
+        value="$(read_env_or_prompt "$env_name" "$prompt" "$secret")"
+        ;;
+      generate)
+        generator="$(jq -r ".secrets[$i].generator // \"password\"" "$file")"
+        length="$(jq -r ".secrets[$i].length // 32" "$file")"
+        value="$(generate_value "$generator" "$length")"
+        ;;
+      *)
+        echo "Unsupported type: $type"
+        exit 1
+        ;;
+    esac
 
-    for key in "${keys[@]}"; do
-      local type
-      type="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].type" "$file")"
-
-      local value
-      case "$type" in
-        literal)
-          value="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].value" "$file")"
-          ;;
-        env)
-          local env_name prompt secret
-          env_name="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].name" "$file")"
-          prompt="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].prompt // \"Paste value for ${env_name}: \"" "$file")"
-          secret="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].secret // 1" "$file")"
-          value="$(read_env_or_prompt "$env_name" "$prompt" "$secret")"
-          ;;
-        generate)
-          local generator length
-          generator="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].generator // \"password\"" "$file")"
-          length="$(jq -r --arg key "$key" ".secrets[$i].fields[\$key].length // 32" "$file")"
-          value="$(generate_value "$generator" "$length")"
-          ;;
-        *)
-          echo "Unsupported field type '$type' for $rel_path:$key"
-          exit 1
-          ;;
-      esac
-
-      kv_args+=("$key=$value")
-    done
-
-    "$BAO_BIN" kv put "$mount/$rel_path" "${kv_args[@]}" >/dev/null
-    echo "Seeded: $mount/data/$rel_path"
+    "$SECRETSPEC_BIN" set "$key" "$value" \
+      --provider "$SECRETSPEC_PROVIDER" \
+      --profile "$SECRETSPEC_PROFILE" >/dev/null
+    echo "Seeded via SecretSpec: $key"
   done
+
+  "$SECRETSPEC_BIN" check --provider "$SECRETSPEC_PROVIDER" --profile "$SECRETSPEC_PROFILE" >/dev/null
+  popd >/dev/null
 }
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
 ensure_bao_bin
-ensure_deps
+ensure_secretspec_bin
 
 export BAO_ADDR="${BAO_ADDR:-http://127.0.0.1:8200}"
 export BAO_DEV_ROOT_TOKEN_ID="${BAO_DEV_ROOT_TOKEN_ID:-dev-only-root-token}"
 export BAO_TOKEN="${BAO_TOKEN:-$BAO_DEV_ROOT_TOKEN_ID}"
+export VAULT_TOKEN="$BAO_TOKEN"
+export VAULT_ADDR="$BAO_ADDR"
+export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost}"
+export no_proxy="${no_proxy:-127.0.0.1,localhost}"
+export HTTP_PROXY=
+export HTTPS_PROXY=
+export ALL_PROXY=
+export http_proxy=
+export https_proxy=
+export all_proxy=
 
 start_dev_if_needed
 
 SECRETS_FILE="${SECRETS_FILE:-$ROOT_DIR/bootstrap-secrets.json}"
-write_secrets_from_file "$SECRETS_FILE"
+SECRETSPEC_PROFILE="${SECRETSPEC_PROFILE:-$(jq -r '.profile // "default"' "$SECRETS_FILE")}"
+SECRETSPEC_MOUNT="${SECRETSPEC_MOUNT:-apps}"
+SECRETSPEC_PROVIDER="${SECRETSPEC_PROVIDER:-$(provider_from_addr "$BAO_ADDR")}" 
 
-echo
-printf 'Bootstrap complete.\n'
-printf 'BAO_BIN=%s\n' "$BAO_BIN"
-printf 'BAO_ADDR=%s\n' "$BAO_ADDR"
-printf 'BAO_TOKEN=%s\n' "$BAO_TOKEN"
-printf 'SECRETS_FILE=%s\n' "$SECRETS_FILE"
+"$BAO_BIN" secrets enable -path="$SECRETSPEC_MOUNT" kv-v2 >/dev/null 2>&1 || true
+
+seed_with_secretspec "$SECRETS_FILE"
+
+echo "Bootstrap complete via secretspec.dev"
+echo "SECRETSPEC_PROVIDER=$SECRETSPEC_PROVIDER"

--- a/openbao-secretspec-bootstrap/scripts/bootstrap.sh
+++ b/openbao-secretspec-bootstrap/scripts/bootstrap.sh
@@ -6,27 +6,46 @@ set -euo pipefail
 #   ./scripts/bootstrap.sh
 #
 # Requirements:
-#   - openbao CLI in PATH
+#   - OpenBao CLI in PATH (`bao` or `openbao`) or BAO_BIN set.
 #   - jq in PATH
 
-if ! command -v openbao >/dev/null 2>&1; then
-  echo "openbao CLI not found in PATH. Enter dev shell first: nix develop"
+resolve_bao_bin() {
+  if [[ -n "${BAO_BIN:-}" ]] && [[ -x "${BAO_BIN}" ]]; then
+    echo "$BAO_BIN"
+    return 0
+  fi
+
+  if command -v bao >/dev/null 2>&1; then
+    command -v bao
+    return 0
+  fi
+
+  if command -v openbao >/dev/null 2>&1; then
+    command -v openbao
+    return 0
+  fi
+
+  return 1
+}
+
+if ! BAO_BIN="$(resolve_bao_bin)"; then
+  echo "OpenBao CLI not found. Install it or run ./scripts/install-openbao.sh"
   exit 1
 fi
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "jq not found in PATH. Enter dev shell first: nix develop"
+  echo "jq not found in PATH. Install jq before continuing."
   exit 1
 fi
 
-export BAO_ADDR="http://127.0.0.1:8200"
-export BAO_DEV_ROOT_TOKEN_ID="dev-only-root-token"
+export BAO_ADDR="${BAO_ADDR:-http://127.0.0.1:8200}"
+export BAO_DEV_ROOT_TOKEN_ID="${BAO_DEV_ROOT_TOKEN_ID:-dev-only-root-token}"
 
-if pgrep -f "openbao server -dev" >/dev/null 2>&1; then
+if pgrep -f "${BAO_BIN} server -dev" >/dev/null 2>&1; then
   echo "OpenBao dev server already running."
 else
-  echo "Starting OpenBao dev server..."
-  nohup openbao server -dev -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
+  echo "Starting OpenBao dev server with ${BAO_BIN}..."
+  nohup "$BAO_BIN" server -dev -dev-root-token-id="$BAO_DEV_ROOT_TOKEN_ID" \
     > .openbao-dev.log 2>&1 &
   sleep 2
 fi
@@ -34,11 +53,11 @@ fi
 export BAO_TOKEN="$BAO_DEV_ROOT_TOKEN_ID"
 
 echo "Checking OpenBao status..."
-openbao status >/dev/null
+"$BAO_BIN" status >/dev/null
 
 # Create a sample kv-v2 secret.
-openbao secrets enable -path=apps kv-v2 >/dev/null 2>&1 || true
-openbao kv put apps/payments/api \
+"$BAO_BIN" secrets enable -path=apps kv-v2 >/dev/null 2>&1 || true
+"$BAO_BIN" kv put apps/payments/api \
   username="payments-service" \
   password="replace-me" \
   endpoint="https://api.example.internal" >/dev/null
@@ -46,9 +65,10 @@ openbao kv put apps/payments/api \
 echo "Wrote secret to: apps/data/payments/api"
 
 echo "\nCurrent secret (redact before sharing):"
-openbao kv get -format=json apps/payments/api \
+"$BAO_BIN" kv get -format=json apps/payments/api \
   | jq '.data.data | with_entries(if .key == "password" then .value = "***REDACTED***" else . end)'
 
 echo "\nBootstrap complete."
+echo "BAO_BIN=$BAO_BIN"
 echo "BAO_ADDR=$BAO_ADDR"
 echo "BAO_TOKEN=$BAO_TOKEN"

--- a/openbao-secretspec-bootstrap/scripts/install-openbao.sh
+++ b/openbao-secretspec-bootstrap/scripts/install-openbao.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs a local OpenBao CLI binary into ./.tools/bin (repo-local).
+# Defaults to v2.5.3 for reproducibility; override with BAO_VERSION.
+
+BAO_VERSION="${BAO_VERSION:-2.5.3}"
+OS="${OS:-Linux}"
+ARCH_RAW="$(uname -m)"
+
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH_RAW"
+    exit 1
+    ;;
+esac
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.tools/bin"
+mkdir -p "$TOOLS_DIR"
+
+TARBALL="bao_${BAO_VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/${TARBALL}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading ${URL}"
+curl -fsSL "$URL" -o "$TMP_DIR/$TARBALL"
+
+tar -xzf "$TMP_DIR/$TARBALL" -C "$TMP_DIR"
+
+if [[ ! -f "$TMP_DIR/bao" ]]; then
+  echo "Expected 'bao' binary not found in archive"
+  exit 1
+fi
+
+install -m 0755 "$TMP_DIR/bao" "$TOOLS_DIR/bao"
+
+echo "Installed: $TOOLS_DIR/bao"
+echo "Run with: BAO_BIN=$TOOLS_DIR/bao"

--- a/openbao-secretspec-bootstrap/scripts/install-secretspec.sh
+++ b/openbao-secretspec-bootstrap/scripts/install-secretspec.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${SECRETSPEC_VERSION:-0.8.2}"
+ARCH_RAW="$(uname -m)"
+OS_RAW="$(uname -s)"
+
+case "$OS_RAW" in
+  Linux) OS="unknown-linux-gnu" ;;
+  Darwin) OS="apple-darwin" ;;
+  *) echo "Unsupported OS: $OS_RAW"; exit 1 ;;
+esac
+
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="aarch64" ;;
+  *) echo "Unsupported architecture: $ARCH_RAW"; exit 1 ;;
+esac
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_DIR="$ROOT_DIR/.tools/bin"
+mkdir -p "$TOOLS_DIR"
+
+ASSET="secretspec-${ARCH}-${OS}.tar.xz"
+URL="https://github.com/cachix/secretspec/releases/download/v${VERSION}/${ASSET}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading ${URL}"
+curl -fsSL "$URL" -o "$TMP_DIR/$ASSET"
+
+tar -xJf "$TMP_DIR/$ASSET" -C "$TMP_DIR"
+BIN_PATH="$(find "$TMP_DIR" -type f -name secretspec | head -n 1)"
+if [[ -z "${BIN_PATH:-}" ]]; then
+  echo "Expected secretspec binary not found"
+  exit 1
+fi
+
+install -m 0755 "$BIN_PATH" "$TOOLS_DIR/secretspec"
+
+echo "Installed: $TOOLS_DIR/secretspec"

--- a/openbao-secretspec-bootstrap/scripts/smoke-test.sh
+++ b/openbao-secretspec-bootstrap/scripts/smoke-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BAO_BIN_DEFAULT="$ROOT_DIR/.tools/bin/bao"
+export BAO_BIN="${BAO_BIN:-$BAO_BIN_DEFAULT}"
+export BAO_ADDR="${BAO_ADDR:-http://127.0.0.1:8200}"
+export BAO_DEV_ROOT_TOKEN_ID="${BAO_DEV_ROOT_TOKEN_ID:-dev-only-root-token}"
+export BAO_TOKEN="$BAO_DEV_ROOT_TOKEN_ID"
+
+if [[ ! -x "$BAO_BIN" ]]; then
+  echo "Missing BAO binary at $BAO_BIN"
+  echo "Run: ./scripts/install-openbao.sh"
+  exit 1
+fi
+
+"$ROOT_DIR/scripts/bootstrap.sh"
+
+USERNAME="$("$BAO_BIN" kv get -field=username apps/payments/api)"
+ENDPOINT="$("$BAO_BIN" kv get -field=endpoint apps/payments/api)"
+
+if [[ "$USERNAME" != "payments-service" ]]; then
+  echo "Unexpected username: $USERNAME"
+  exit 1
+fi
+
+if [[ "$ENDPOINT" != "https://api.example.internal" ]]; then
+  echo "Unexpected endpoint: $ENDPOINT"
+  exit 1
+fi
+
+echo "Smoke test passed."

--- a/openbao-secretspec-bootstrap/scripts/smoke-test.sh
+++ b/openbao-secretspec-bootstrap/scripts/smoke-test.sh
@@ -2,49 +2,49 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BAO_BIN_DEFAULT="$ROOT_DIR/.tools/bin/bao"
-export BAO_BIN="${BAO_BIN:-$BAO_BIN_DEFAULT}"
-export BAO_ADDR="${BAO_ADDR:-http://127.0.0.1:8200}"
+export BAO_BIN="${BAO_BIN:-$ROOT_DIR/.tools/bin/bao}"
+export SECRETSPEC_BIN="${SECRETSPEC_BIN:-$ROOT_DIR/.tools/bin/secretspec}"
+
+if [[ ! -x "$BAO_BIN" ]]; then
+  "$ROOT_DIR/scripts/install-openbao.sh"
+fi
+if [[ ! -x "$SECRETSPEC_BIN" ]]; then
+  "$ROOT_DIR/scripts/install-secretspec.sh"
+fi
+
+if [[ -z "${BAO_ADDR:-}" ]]; then
+  TEST_PORT="$((19000 + (RANDOM % 1000)))"
+  export BAO_ADDR="http://127.0.0.1:${TEST_PORT}"
+else
+  TEST_PORT="${BAO_ADDR##*:}"
+fi
 export BAO_DEV_ROOT_TOKEN_ID="${BAO_DEV_ROOT_TOKEN_ID:-dev-only-root-token}"
 export BAO_TOKEN="${BAO_TOKEN:-$BAO_DEV_ROOT_TOKEN_ID}"
-export SECRETS_FILE="${SECRETS_FILE:-$ROOT_DIR/bootstrap-secrets.json}"
-
-# Non-interactive values that would normally be pasted from third parties.
+export VAULT_TOKEN="$BAO_TOKEN"
+export VAULT_ADDR="$BAO_ADDR"
+export HTTP_PROXY=
+export HTTPS_PROXY=
+export ALL_PROXY=
+export http_proxy=
+export https_proxy=
+export all_proxy=
 export PAYMENTS_ENDPOINT="${PAYMENTS_ENDPOINT:-https://api.example.internal}"
 export STRIPE_API_KEY="${STRIPE_API_KEY:-sk_test_example_key}"
 export STRIPE_WEBHOOK_SECRET="${STRIPE_WEBHOOK_SECRET:-whsec_example_secret}"
 
-if [[ ! -x "$BAO_BIN" ]]; then
-  echo "Missing BAO binary at $BAO_BIN"
-  echo "Run: ./scripts/install-openbao.sh"
-  exit 1
-fi
-
 "$ROOT_DIR/scripts/bootstrap.sh"
 
-USERNAME="$($BAO_BIN kv get -field=username apps/payments/api)"
-ENDPOINT="$($BAO_BIN kv get -field=endpoint apps/payments/api)"
-STRIPE_KEY="$($BAO_BIN kv get -field=api_key apps/thirdparty/stripe)"
-ROTATION_ID="$($BAO_BIN kv get -field=rotation_id apps/thirdparty/stripe)"
+PROVIDER="${SECRETSPEC_PROVIDER:-openbao://127.0.0.1:${TEST_PORT}/apps?tls=false}"
+PROFILE="${SECRETSPEC_PROFILE:-default}"
 
-if [[ "$USERNAME" != "payments-service" ]]; then
-  echo "Unexpected username: $USERNAME"
-  exit 1
-fi
+PAYMENTS_USER="$($SECRETSPEC_BIN get PAYMENTS_USERNAME --provider "$PROVIDER" --profile "$PROFILE")"
+PAYMENTS_URL="$($SECRETSPEC_BIN get PAYMENTS_ENDPOINT --provider "$PROVIDER" --profile "$PROFILE")"
+STRIPE_KEY="$($SECRETSPEC_BIN get STRIPE_API_KEY --provider "$PROVIDER" --profile "$PROFILE")"
+ROTATION_ID="$($SECRETSPEC_BIN get STRIPE_ROTATION_ID --provider "$PROVIDER" --profile "$PROFILE")"
 
-if [[ "$ENDPOINT" != "$PAYMENTS_ENDPOINT" ]]; then
-  echo "Unexpected endpoint: $ENDPOINT"
-  exit 1
-fi
+[[ "$PAYMENTS_USER" == "payments-service" ]] || { echo "Unexpected PAYMENTS_USERNAME"; exit 1; }
+[[ "$PAYMENTS_URL" == "$PAYMENTS_ENDPOINT" ]] || { echo "Unexpected PAYMENTS_ENDPOINT"; exit 1; }
+[[ "$STRIPE_KEY" == "$STRIPE_API_KEY" ]] || { echo "Unexpected STRIPE_API_KEY"; exit 1; }
+[[ -n "$ROTATION_ID" ]] || { echo "Missing STRIPE_ROTATION_ID"; exit 1; }
 
-if [[ "$STRIPE_KEY" != "$STRIPE_API_KEY" ]]; then
-  echo "Unexpected Stripe key"
-  exit 1
-fi
-
-if [[ -z "$ROTATION_ID" ]]; then
-  echo "rotation_id was not generated"
-  exit 1
-fi
-
-echo "Smoke test passed."
+echo "Smoke test passed (SecretSpec + OpenBao provider)."

--- a/openbao-secretspec-bootstrap/scripts/smoke-test.sh
+++ b/openbao-secretspec-bootstrap/scripts/smoke-test.sh
@@ -6,7 +6,13 @@ BAO_BIN_DEFAULT="$ROOT_DIR/.tools/bin/bao"
 export BAO_BIN="${BAO_BIN:-$BAO_BIN_DEFAULT}"
 export BAO_ADDR="${BAO_ADDR:-http://127.0.0.1:8200}"
 export BAO_DEV_ROOT_TOKEN_ID="${BAO_DEV_ROOT_TOKEN_ID:-dev-only-root-token}"
-export BAO_TOKEN="$BAO_DEV_ROOT_TOKEN_ID"
+export BAO_TOKEN="${BAO_TOKEN:-$BAO_DEV_ROOT_TOKEN_ID}"
+export SECRETS_FILE="${SECRETS_FILE:-$ROOT_DIR/bootstrap-secrets.json}"
+
+# Non-interactive values that would normally be pasted from third parties.
+export PAYMENTS_ENDPOINT="${PAYMENTS_ENDPOINT:-https://api.example.internal}"
+export STRIPE_API_KEY="${STRIPE_API_KEY:-sk_test_example_key}"
+export STRIPE_WEBHOOK_SECRET="${STRIPE_WEBHOOK_SECRET:-whsec_example_secret}"
 
 if [[ ! -x "$BAO_BIN" ]]; then
   echo "Missing BAO binary at $BAO_BIN"
@@ -16,16 +22,28 @@ fi
 
 "$ROOT_DIR/scripts/bootstrap.sh"
 
-USERNAME="$("$BAO_BIN" kv get -field=username apps/payments/api)"
-ENDPOINT="$("$BAO_BIN" kv get -field=endpoint apps/payments/api)"
+USERNAME="$($BAO_BIN kv get -field=username apps/payments/api)"
+ENDPOINT="$($BAO_BIN kv get -field=endpoint apps/payments/api)"
+STRIPE_KEY="$($BAO_BIN kv get -field=api_key apps/thirdparty/stripe)"
+ROTATION_ID="$($BAO_BIN kv get -field=rotation_id apps/thirdparty/stripe)"
 
 if [[ "$USERNAME" != "payments-service" ]]; then
   echo "Unexpected username: $USERNAME"
   exit 1
 fi
 
-if [[ "$ENDPOINT" != "https://api.example.internal" ]]; then
+if [[ "$ENDPOINT" != "$PAYMENTS_ENDPOINT" ]]; then
   echo "Unexpected endpoint: $ENDPOINT"
+  exit 1
+fi
+
+if [[ "$STRIPE_KEY" != "$STRIPE_API_KEY" ]]; then
+  echo "Unexpected Stripe key"
+  exit 1
+fi
+
+if [[ -z "$ROTATION_ID" ]]; then
+  echo "rotation_id was not generated"
   exit 1
 fi
 

--- a/openbao-secretspec-bootstrap/secretspec.example.yaml
+++ b/openbao-secretspec-bootstrap/secretspec.example.yaml
@@ -1,0 +1,25 @@
+apiVersion: secretspec.dev/v1alpha1
+kind: SecretSpec
+metadata:
+  name: payments-api
+  namespace: default
+spec:
+  provider:
+    type: openbao
+    address: http://127.0.0.1:8200
+    auth:
+      method: token
+      tokenFromEnv: BAO_TOKEN
+  source:
+    path: apps/data/payments/api
+    format: kv-v2
+  target:
+    name: payments-api-secret
+    type: Opaque
+  mappings:
+    - sourceKey: username
+      targetKey: username
+    - sourceKey: password
+      targetKey: password
+    - sourceKey: endpoint
+      targetKey: endpoint

--- a/openbao-secretspec-bootstrap/secretspec.toml
+++ b/openbao-secretspec-bootstrap/secretspec.toml
@@ -1,0 +1,11 @@
+[project]
+name = "openbao-secretspec-bootstrap"
+revision = "1.0"
+
+[profiles.default]
+PAYMENTS_USERNAME = { description = "Payments service username", required = true }
+PAYMENTS_PASSWORD = { description = "Payments service password", required = true }
+PAYMENTS_ENDPOINT = { description = "Payments API endpoint", required = true }
+STRIPE_API_KEY = { description = "Stripe API key", required = true }
+STRIPE_WEBHOOK_SECRET = { description = "Stripe webhook secret", required = true }
+STRIPE_ROTATION_ID = { description = "Generated Stripe rotation UUID", required = true }


### PR DESCRIPTION
### Motivation
- Provide a minimal, reproducible experiment that boots OpenBao in dev mode and demonstrates a SecretSpec mapping for a seeded secret.  
- Keep the workflow small and self-contained inside a new top-level experiment directory with a Nix dev shell for repeatable tooling.

### Description
- Add a new experiment directory `openbao-secretspec-bootstrap` containing `flake.nix` and `.envrc` to define a Nix dev shell with `openbao`, `jq`, `just`, and helpers.  
- Add `scripts/bootstrap.sh`, which starts an OpenBao dev server (`openbao server -dev -dev-root-token-id=...`), enables a KV v2 mount at `apps`, and seeds a sample secret (`openbao kv put apps/payments/api ...`).  
- Add `secretspec.example.yaml` with a `SecretSpec` that references the seeded OpenBao path and maps keys (`username`, `password`, `endpoint`) to a target secret.  
- Add workflow helpers and docs: a `justfile` with `bootstrap`/`status`/`show-secret`/`stop` targets, plus `program.md`, `notes.md`, and `README.md` to capture objective, reproducibility steps, and experiment notes.

### Testing
- Ran a shell syntax check on the bootstrap script with `bash -n openbao-secretspec-bootstrap/scripts/bootstrap.sh`, which passed.  
- Verified repository status and that the new files are present via `git status --short`, which showed the experiment staged/committed as expected.  
- Runtime execution of the `openbao` CLI (starting the server and writing secrets) was not executed in this environment and remains unvalidated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece238e130832ba9a25bdcfe8726f7)